### PR TITLE
fix: configure multiple network interface IPs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,9 @@ resource "azurerm_network_interface" "this" {
       private_ip_address_allocation = "Dynamic"
 
       # A public IP address should not be attached directly to a NIC.
+
+      # If configuring multiple IP configurations, the first configuration should be set as primary.
+      primary = length(each.value.ip_configurations) > 1 && index(each.value.ip_configurations, ip_configuration.value) == 0
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,9 +19,9 @@ output "admin_password" {
   sensitive   = true
 }
 
-output "network_interface_private_ip_addresses" {
-  description = "A map of network interface private IP addresses."
+output "private_ip_addresses" {
+  description = "A map of private IP addresses for the network interfaces of this VM."
   value = {
-    for k, v in azurerm_network_interface.this : k => v.private_ip_address
+    for k, v in azurerm_network_interface.this : k => v.private_ip_addresses
   }
 }


### PR DESCRIPTION
- Automatically set first IP configuration as primary. Required when configuring multiple IPs.
- Shorten output `network_interface_ip_addresses` name to `pivate_ip_addresses`, since these private IP addresses are for the entire VM, not **just** the network interfaces. Not a breaking change since this output has not been part of a release yet.
- Update output `pivate_ip_addresses` value to output **all** IP addresses, not just primary.