### PR TITLE
fix: error when using Random provider v3.2.0 or lower

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = ">= 2.2.0"
+      version = ">= 3.3.0"
     }
   }
 }


### PR DESCRIPTION
Argument `numeric` was added to resource `random_password` in Random provider v3.3.0. See [Random provider changelog](https://github.com/hashicorp/terraform-provider-random/blob/5f4ba710cbf50c52ebb57df8f109c6da647d81b7/CHANGELOG.md#330-june-06-2022) for reference.

Fixes equinor/terraform-baseline#205.